### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is an example static site.
 
-[Read the documentation](https://docs.letsdisco.dev/guides/deploying-a-static-site) on how to deploy static sites using disco.
+[Read the documentation](https://docs.letsdisco.dev/deployment-guides/static-site) on how to deploy static sites using disco.


### PR DESCRIPTION
I noticed the link was incorrect. (I'm assuming it pointed to a previous version of the docs.) This change links to what seems to be the right page.